### PR TITLE
Fix/windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ git2 = "0.10.1"
 glob = "0.3.0"
 serde = { version = "1.0.101", features = ["derive"] }
 toml = "0.5.3"
-[target.'cfg(not(target_os = "windows"))'. dependencies]
+[target.'cfg(target_family = "unix")'. dependencies]
 termion = "1.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ duct = "0.13.0"
 git2 = "0.10.1"
 glob = "0.3.0"
 serde = { version = "1.0.101", features = ["derive"] }
-termion = "1.5.3"
 toml = "0.5.3"
+[target.'cfg(not(target_os = "windows"))'. dependencies]
+termion = "1.5.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ impl Selector {
             if desc.len() > 0 {
                 desc = format!(" - {}", desc);
             }
+            #[cfg(not(target_os = "windows"))]
             println!("{}{}{}{}{}\n\t{}\n", color::Fg(color::Yellow), style::Bold, name, style::Reset, desc, e.url);
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 use termion::{color, style};
 
 use super::library::{Entry, Library};
@@ -25,8 +25,10 @@ impl Selector {
             if desc.len() > 0 {
                 desc = format!(" - {}", desc);
             }
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(target_family = "unix")]
             println!("{}{}{}{}{}\n\t{}\n", color::Fg(color::Yellow), style::Bold, name, style::Reset, desc, e.url);
+            #[cfg(target_family = "windows")]
+            println!("{}{}\n\t{}\n",name, desc, e.url);
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "windows"))]
 use termion::{color, style};
 
 use super::library::{Entry, Library};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate clap;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 extern crate termion;
 
 use clap::{Arg, App, crate_authors, crate_version};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate clap;
+#[cfg(not(target_os = "windows"))]
 extern crate termion;
 
 use clap::{Arg, App, crate_authors, crate_version};


### PR DESCRIPTION
Introduce conditional compiling checks for windows as termion supports only ANSI terminals
[Support Windows and cross-compile binaries](https://github.com/streamlib/streamlib/issues/7)

Has been tested & compiled for windows 10 (+windows 7) 